### PR TITLE
feat(font): apply Arial, Calibri, Open Sans, Roboto + Times New Roman…

### DIFF
--- a/font/css/main.css
+++ b/font/css/main.css
@@ -1,0 +1,12 @@
+:root {
+  --font-sans: Arial, Calibri, 'Open Sans', Roboto, sans-serif;
+  --font-serif: 'Times New Roman', Georgia, serif;
+}
+
+body {
+  font-family: var(--font-sans);
+}
+
+.heading-serif {
+  font-family: var(--font-serif);
+}


### PR DESCRIPTION
…, Georgia

## Summary by Sourcery

Introduce CSS variables for sans-serif and serif font stacks and apply them to the body and headings.

New Features:
- Define --font-sans and --font-serif variables with respective font stacks.
- Apply the sans-serif stack to the body and the serif stack to elements with the heading-serif class.