### PR TITLE
build useModal

### DIFF
--- a/composables/useModal.js
+++ b/composables/useModal.js
@@ -1,0 +1,103 @@
+import {
+  computed,
+  onUnmounted,
+  watch,
+  ref,
+} from 'vue'
+
+export function useModal(
+  props,
+  emit,
+  slots,
+) {
+  const isConfirmModal = computed(
+    () => !slots.body
+      && !slots.footer
+  )
+
+  const hasEventListener = ref(false)
+
+  const closeModal = () => {
+    emit(
+      'update:isVisible',
+      false,
+    )
+
+    emit('close')
+  }
+
+  const handleBackdropClick = () => {
+    if (props.closeOnClickOutside) {
+      closeModal()
+    }
+  }
+
+  const handleEscPress = (keyboardEvent) => {
+    if (props.closeOnEsc
+      && keyboardEvent.key
+      === 'Escape'
+    ) {
+
+      closeModal()
+      keyboardEvent.stopPropagation()
+      keyboardEvent.preventDefault()
+    }
+  }
+
+  const addModalEventListeners = () => {
+    if (!hasEventListener.value) {
+      window.addEventListener(
+        'keydown',
+        handleEscPress,
+      )
+
+      hasEventListener.value = true
+    }
+  }
+
+  const removeModalEventListeners = () => {
+    if (hasEventListener.value) {
+      window.removeEventListener(
+        'keydown',
+        handleEscPress,
+      )
+
+      hasEventListener.value = false
+    }
+  }
+
+  watch(
+    () => props.isVisible,
+    isModalOpen => {
+      if (isModalOpen) {
+        document.body
+          .style
+          .overflow = 'hidden'
+        addModalEventListeners()
+
+        return
+      }
+
+      document.body.style.overflow = ''
+      removeModalEventListeners()
+    },
+    {
+      immediate: false,
+    }
+  )
+
+  onUnmounted(() => {
+    removeModalEventListeners()
+
+    if (props.isVisible) {
+      document.body.style.overflow = ''
+    }
+  })
+
+  return {
+    isConfirmModal,
+    closeModal,
+    handleEscPress,
+    handleBackdropClick,
+  }
+}


### PR DESCRIPTION
## Build useModal

## Summary by Sourcery

Introduce a new useModal composable to encapsulate modal behavior and lifecycle management

New Features:
- Add isConfirmModal computed flag based on slot presence
- Implement closeModal function to emit visibility updates and close events
- Handle backdrop clicks and Escape key presses to close the modal when enabled via props
- Lock page scroll and attach/detach Escape key listener when modal visibility changes
- Clean up event listeners and restore scroll state on component unmount