### PR TITLE
build useModal composables

### DIFF
--- a/composables/useModal.js
+++ b/composables/useModal.js
@@ -1,0 +1,103 @@
+import {
+  computed,
+  onUnmounted,
+  watch,
+  ref,
+} from 'vue'
+
+export function useModal(
+  props,
+  emit,
+  slots,
+) {
+  const isConfirmModal = computed(
+    () => !slots.body
+      && !slots.footer
+  )
+
+  const hasEventListener = ref(false)
+
+  const closeModal = () => {
+    emit(
+      'update:isVisible',
+      false,
+    )
+
+    emit('close')
+  }
+
+  const handleBackdropClick = () => {
+    if (props.closeOnClickOutside) {
+      closeModal()
+    }
+  }
+
+  const handleEscPress = (keyboardEvent) => {
+    if (props.closeOnEsc
+      && keyboardEvent.key
+      === 'Escape'
+    ) {
+
+      closeModal()
+      keyboardEvent.stopPropagation()
+      keyboardEvent.preventDefault()
+    }
+  }
+
+  const addModalEventListeners = () => {
+    if (!hasEventListener.value) {
+      window.addEventListener(
+        'keydown',
+        handleEscPress,
+      )
+
+      hasEventListener.value = true
+    }
+  }
+
+  const removeModalEventListeners = () => {
+    if (hasEventListener.value) {
+      window.removeEventListener(
+        'keydown',
+        handleEscPress,
+      )
+
+      hasEventListener.value = false
+    }
+  }
+
+  watch(
+    () => props.isVisible,
+    isModalOpen => {
+      if (isModalOpen) {
+        document.body
+          .style
+          .overflow = 'hidden'
+        addModalEventListeners()
+
+        return
+      }
+
+      document.body.style.overflow = ''
+      removeModalEventListeners()
+    },
+    {
+      immediate: false,
+    }
+  )
+
+  onUnmounted(() => {
+    removeModalEventListeners()
+
+    if (props.isVisible) {
+      document.body.style.overflow = ''
+    }
+  })
+
+  return {
+    isConfirmModal,
+    closeModal,
+    handleEscPress,
+    handleBackdropClick,
+  }
+}


### PR DESCRIPTION
## Build useModal for Modal component

## Summary by Sourcery

Extract modal behavior into a reusable useModal composable to standardize visibility control, event handling, and cleanup for modal components.

New Features:
- Introduce useModal composable to encapsulate modal open/close logic, backdrop click handling, and Escape key closures

Enhancements:
- Compute confirmation-only modal mode when no body or footer slots are provided
- Disable document body scrolling and attach Escape key listener when modal is visible
- Restore body overflow style and remove event listeners on modal close or component unmount