### PR TITLE
fix demo-page

### DIFF
--- a/pages/DemoButton/index.vue
+++ b/pages/DemoButton/index.vue
@@ -1,0 +1,194 @@
+<script>
+import {
+  defineComponent,
+} from "vue"
+
+import Button from "~/components/Button.vue"
+
+export default defineComponent({
+  name: "DemoButton",
+
+  components: {
+    Button,
+  },
+})
+</script>
+
+<template>
+  <div class="unit-container">
+    <h1>
+      Button Component Demo
+    </h1>
+
+    <!-- Variant Buttons -->
+    <section class="unit-content">
+      <h2>
+        Solid Variant
+      </h2>
+      <div class="unit-button">
+        <Button
+          variant="primary"
+        >
+          Primary
+        </Button>
+        <Button
+          variant="secondary"
+        >
+          Secondary
+        </Button>
+        <Button
+          variant="success"
+        >
+          Success
+        </Button>
+        <Button
+          variant="danger"
+        >
+          Danger
+        </Button>
+        <Button
+          variant="warning"
+        >
+          Warning
+        </Button>
+      </div>
+    </section>
+
+    <!-- Outline Buttons -->
+    <section class="unit-content">
+      <h2>
+        Outline Variant
+      </h2>
+      <div class="unit-button">
+        <Button
+          variant="outline-primary"
+        >
+          Primary
+        </Button>
+        <Button
+          variant="outline-secondary"
+        >
+          Secondary
+        </Button>
+        <Button
+          variant="outline-success"
+        >
+          Success
+        </Button>
+        <Button
+          variant="outline-danger"
+        >
+          Danger
+        </Button>
+        <Button
+          variant="outline-warning"
+        >
+          Warning
+        </Button>
+      </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="unit-content">
+      <h2>
+        Disabled
+      </h2>
+      <div class="unit-button">
+        <Button
+          variant="outline-primary"
+          disabled
+        >
+          Primary
+        </Button>
+        <Button
+          variant="outline-secondary"
+          disabled
+        >
+          Secondary
+        </Button>
+        <Button
+          variant="outline-success"
+          disabled
+        >
+          Success
+        </Button>
+        <Button
+          variant="outline-danger"
+          disabled
+        >
+          Danger
+        </Button>
+        <Button
+          variant="outline-warning"
+          disabled
+        >
+          Warning
+        </Button>
+      </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="unit-content">
+      <h2>
+        Loading
+      </h2>
+      <div class="unit-button">
+        <Button
+          variant="outline-primary"
+          :loading="true"
+        >
+          Primary
+        </Button>
+        <Button
+          variant="outline-secondary"
+          :loading="true"
+        >
+          Secondary
+        </Button>
+        <Button
+          variant="outline-success"
+          :loading="true"
+        >
+          Success
+        </Button>
+        <Button
+          variant="outline-danger"
+          :loading="true"
+        >
+          Danger
+        </Button>
+        <Button
+          variant="outline-warning"
+          :loading="true"
+        >
+          Warning
+        </Button>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.unit-container {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: var(--size-space-medium);
+
+  padding-block: var(--size-space-medium);
+  padding-inline: var(--size-space-medium);
+}
+
+.unit-container > .unit-content {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: var(--size-space-medium);
+}
+
+.unit-container > .unit-content > .unit-button {
+  display: flex;
+  align-items: center;
+  gap: var(--size-space-small);
+}
+</style>

--- a/pages/DemoModal/index.vue
+++ b/pages/DemoModal/index.vue
@@ -5,12 +5,14 @@ import {
 } from "vue"
 
 import Modal from "~/components/Modal.vue"
+import Button from "~/components/Button.vue"
 
 export default defineComponent({
   name: "DemoModal",
 
   components: {
     Modal,
+    Button,
   },
 
   setup() {
@@ -36,11 +38,12 @@ export default defineComponent({
 
 <template>
   <div class="page">
-    <button
+    <Button
+      variant="primary"
       @click="openModal"
     >
       Mở Modal
-    </button>
+    </Button>
 
     <Modal
       :isVisible="isVisible"
@@ -55,11 +58,12 @@ export default defineComponent({
       </template>
 
       <template #footer>
-        <button
+        <Button
+          variant="danger"
           @click="closeModal"
         >
           Xác nhận
-        </button>
+        </Button>
       </template>
     </Modal>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
 </script>
 
 <template>
-  <div class="page">z``
+  <div class="page">
     <!-- Header -->
     <header class="header">
       <h1 class="title">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,194 +1,143 @@
 <script>
-import {
-  defineComponent,
-} from "vue"
-
-import Button from "~/components/Button.vue"
-
-export default defineComponent({
-  name: "DemoButton",
-
-  components: {
-    Button,
-  },
-})
 </script>
 
 <template>
-  <div class="unit-container">
-    <h1>
-      Button Component Demo
-    </h1>
+  <div class="page">z``
+    <!-- Header -->
+    <header class="header">
+      <h1 class="title">
+        Trang Chủ
+      </h1>
+      <nav class="nav">
+        <a
+          href="#"
+          class="link"
+        >Trang chủ</a>
+        <a
+          href="#"
+          class="link"
+        >Giới thiệu</a>
+        <a
+          href="#"
+          class="link"
+        >Liên hệ</a>
+      </nav>
+    </header>
 
-    <!-- Variant Buttons -->
-    <section class="unit-content">
-      <h2>
-        Solid Variant
-      </h2>
-      <div class="unit-button">
-        <Button
-          variant="primary"
-        >
-          Primary
-        </Button>
-        <Button
-          variant="secondary"
-        >
-          Secondary
-        </Button>
-        <Button
-          variant="success"
-        >
-          Success
-        </Button>
-        <Button
-          variant="danger"
-        >
-          Danger
-        </Button>
-        <Button
-          variant="warning"
-        >
-          Warning
-        </Button>
-      </div>
-    </section>
+    <!-- Main content -->
+    <main class="content">
+      <section class="card">
+        <h2 class="heading">
+          Xin chào 👋
+        </h2>
+        <p>Đây là template demo cho <code>pages/index.vue</code> sử dụng các biến CSS.</p>
+      </section>
 
-    <!-- Outline Buttons -->
-    <section class="unit-content">
-      <h2>
-        Outline Variant
-      </h2>
-      <div class="unit-button">
-        <Button
-          variant="outline-primary"
-        >
-          Primary
-        </Button>
-        <Button
-          variant="outline-secondary"
-        >
-          Secondary
-        </Button>
-        <Button
-          variant="outline-success"
-        >
-          Success
-        </Button>
-        <Button
-          variant="outline-danger"
-        >
-          Danger
-        </Button>
-        <Button
-          variant="outline-warning"
-        >
-          Warning
-        </Button>
-      </div>
-    </section>
+      <section class="card">
+        <h2 class="heading">
+          Màu sắc từ variables.css
+        </h2>
+        <div class="colors">
+          <div
+            class="color-box"
+            style="background: var(--color-blue-500)"
+          >
+            Blue 500
+          </div>
+          <div
+            class="color-box"
+            style="background: var(--color-purple-500)"
+          >
+            Purple 500
+          </div>
+          <div
+            class="color-box"
+            style="background: var(--color-rose-500)"
+          >
+            Rose 500
+          </div>
+        </div>
+      </section>
+    </main>
 
-    <!-- Disabled -->
-    <section class="unit-content">
-      <h2>
-        Disabled
-      </h2>
-      <div class="unit-button">
-        <Button
-          variant="outline-primary"
-          disabled
-        >
-          Primary
-        </Button>
-        <Button
-          variant="outline-secondary"
-          disabled
-        >
-          Secondary
-        </Button>
-        <Button
-          variant="outline-success"
-          disabled
-        >
-          Success
-        </Button>
-        <Button
-          variant="outline-danger"
-          disabled
-        >
-          Danger
-        </Button>
-        <Button
-          variant="outline-warning"
-          disabled
-        >
-          Warning
-        </Button>
-      </div>
-    </section>
-
-    <!-- Loading -->
-    <section class="unit-content">
-      <h2>
-        Loading
-      </h2>
-      <div class="unit-button">
-        <Button
-          variant="outline-primary"
-          :loading="true"
-        >
-          Primary
-        </Button>
-        <Button
-          variant="outline-secondary"
-          :loading="true"
-        >
-          Secondary
-        </Button>
-        <Button
-          variant="outline-success"
-          :loading="true"
-        >
-          Success
-        </Button>
-        <Button
-          variant="outline-danger"
-          :loading="true"
-        >
-          Danger
-        </Button>
-        <Button
-          variant="outline-warning"
-          :loading="true"
-        >
-          Warning
-        </Button>
-      </div>
-    </section>
+    <!-- Footer -->
+    <footer class="footer">
+      <p>© 2025 Demo Project</p>
+    </footer>
   </div>
 </template>
 
 <style scoped>
-.unit-container {
+.page {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: start;
-  gap: var(--size-space-medium);
-
-  padding-block: var(--size-space-medium);
-  padding-inline: var(--size-space-medium);
+  background: var(--color-gray-50);
+  font-family: var(--font-family-sans);
 }
 
-.unit-container > .unit-content {
+/* Header */
+.header {
+  height: var(--size-header-height);
   display: flex;
-  flex-direction: column;
-  align-items: start;
-  gap: var(--size-space-medium);
-}
-
-.unit-container > .unit-content > .unit-button {
-  display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: var(--size-space-small);
+  padding: 0 var(--size-space-large);
+  background: linear-gradient(var(--color-linear-gradient));
+  color: white;
+}
+
+.title {
+  font-size: var(--font-size-title-medium);
+  font-weight: var(--font-weight-bold);
+}
+
+.nav .link {
+  margin-left: var(--size-space-medium);
+  color: var(--color-gray-50);
+  font-size: var(--font-size-body-medium);
+}
+
+/* Content */
+.content {
+  flex: 1;
+  padding: var(--size-space-large);
+  display: grid;
+  gap: var(--size-space-large);
+}
+
+.card {
+  background: white;
+  border-radius: var(--size-border-radius);
+  padding: var(--size-space-large);
+  box-shadow: var(--box-shadow);
+}
+
+.heading {
+  font-size: var(--font-size-heading-large);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--size-space-medium);
+}
+
+.colors {
+  display: flex;
+  gap: var(--size-space-medium);
+}
+
+.color-box {
+  flex: 1;
+  padding: var(--size-space-medium);
+  color: white;
+  border-radius: var(--size-border-radius-small);
+  text-align: center;
+  font-weight: var(--font-weight-medium);
+}
+
+/* Footer */
+.footer {
+  text-align: center;
+  padding: var(--size-space-medium);
+  background: var(--color-gray-200);
+  font-size: var(--font-size-body-small);
 }
 </style>


### PR DESCRIPTION
## fix demo-page

## Summary by Sourcery

Revamp demo pages by transforming the root index page into a localized homepage layout, extracting the button showcase into its own route, and standardizing modal actions with the Button component.

Enhancements:
- Overhaul pages/index.vue to serve as a Vietnamese homepage with a header, content cards showing CSS variable colors, and a footer, all styled via CSS variables
- Introduce pages/DemoButton/index.vue to host the standalone button component demo
- Update pages/DemoModal/index.vue to import and use the Button component for opening and confirming the modal