### PR TITLE
fix background color for default layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -14,7 +14,7 @@ export default {
 </script>
 
 <template>
-  <div class="unit-container">
+  <div class="unit-default-container">
     <Header />
 
     <div class="unit-content">
@@ -28,10 +28,9 @@ export default {
 </template>
 
 <style>
-.unit-container {
-
+.unit-default-container {
   color: var(--color-zinc-900);
-  background-color: var(--color-zinc-50);
+  background-color: var(--color-gray-50);
 }
 </style>
 


### PR DESCRIPTION
## Fix background-color for Default Layout

## Summary by Sourcery

Fix default layout styling by renaming the container class and updating its background color

Bug Fixes:
- Rename default layout container class from 'unit-container' to 'unit-default-container'
- Update default layout background-color to use var(--color-gray-50) instead of var(--color-zinc-50)