### PR TITLE
add badge component into header

### DIFF
--- a/components/Layout/Header.vue
+++ b/components/Layout/Header.vue
@@ -8,12 +8,14 @@ import {
 } from "#components"
 
 import Dropdown from "~/components/Dropdown.vue"
+import Badge from '~/components/Badge.vue'
 
 export default defineComponent({
   name: "Header",
 
   components: {
     Dropdown,
+    Badge,
     Icon
   },
 })
@@ -24,7 +26,14 @@ export default defineComponent({
     <div class="unit-header-container">
       <!-- Left: Logo -->
       <div class="unit-logo">
-        <h1>QLDT</h1>
+        <Badge
+          color="danger"
+          content="beta"
+        >
+          <span class="logo">
+            QLDT
+          </span>
+        </Badge>
       </div>
       <!-- Right: User actions -->
       <div class="unit-header-actions">
@@ -88,7 +97,7 @@ export default defineComponent({
   justify-content: space-between;
 }
 
-.unit-header > .unit-header-container > .unit-logo > h1 {
+.logo {
   font-size: var(--font-size-heading-large);
   font-weight: var(--font-weight-bold);
   color: var(--color-blue-500);


### PR DESCRIPTION
## Add badge component into header

<img width="643" height="447" alt="image" src="https://github.com/user-attachments/assets/3666f2c3-e20a-4992-91f9-265fbe20cc48" />

## Summary by Sourcery

Wrap the QLDT logo in a beta badge within the header and adjust related styles accordingly

Enhancements:
- Import and register the Badge component in the header
- Replace the static h1 logo with a Badge-wrapped logo displaying a "beta" label
- Update CSS by replacing h1 selector with a .logo class for consistent styling