### PR TITLE
fix css, add sidebar and demo accordion

### DIFF
--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -92,6 +92,10 @@ export default defineComponent({
 .unit-section {
   position: relative;
 
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-space-tiny);
+
   width: 100%;
 }
 
@@ -111,6 +115,9 @@ export default defineComponent({
 
 .unit-section > .accordion-header > .header-content {
   flex: 1;
+
+  display: flex;
+  gap: var(--size-space-tiny);
 }
 
 .unit-section.is-open > .accordion-header > .header-content {
@@ -148,7 +155,12 @@ export default defineComponent({
 }
 
 .unit-section.is-open > .accordion-content {
-  display: block;
+  margin-inline-start: var(--size-space-large);
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-space-tiny);
+
   animation: slide-down 250ms ease;
 }
 

--- a/components/Layout/Sidebar.vue
+++ b/components/Layout/Sidebar.vue
@@ -26,6 +26,10 @@ export default defineComponent({
         iconName: 'ph:monitor',
       },
       {
+        label: 'Accordion',
+        href: '/DemoAccordion',
+      },
+      {
         label: 'Button',
         href: '/DemoButton',
       },

--- a/pages/DemoAccordion/index.vue
+++ b/pages/DemoAccordion/index.vue
@@ -1,0 +1,91 @@
+<script>
+import {
+  defineComponent,
+  ref,
+} from "vue"
+
+import {
+  Icon,
+} from "#components"
+
+import Accordion from "@/components/Accordion.vue"
+
+export default defineComponent({
+  components: {
+    Accordion,
+    Icon,
+  },
+
+  setup () {
+    const qldt = ref(false)
+    const app = ref(false)
+    const contexts = ref(false)
+    const comp = ref(false)
+
+    return {
+      qldt,
+      app,
+      contexts,
+      comp,
+    }
+  }
+})
+</script>
+
+<template>
+  <Accordion
+    v-model:isOpen="qldt"
+  >
+    <template #header>
+      <Icon name="ph:folder" />
+      <h3>qldtbeta</h3>
+    </template>
+
+    <template #content>
+      <Accordion v-model:isOpen="app">
+        <template #header>
+          <Icon name="ph:folder" />
+          <h3>app</h3>
+        </template>
+
+        <template #content>
+          <Accordion v-model:isOpen="contexts">
+            <template #header>
+              <Icon name="ph:folder" />
+              <h3>contexts</h3>
+            </template>
+
+            <template #content>
+              <div class="unit-file">
+                <Icon name="ph:file-js" />
+                <p>AccordionContext.js</p>
+              </div>
+            </template>
+          </Accordion>
+        </template>
+      </Accordion>
+
+      <Accordion v-model:isOpen="comp">
+        <template #header>
+          <Icon name="ph:folder" />
+          <h3>components</h3>
+        </template>
+
+        <template #content>
+          <div class="unit-file">
+            <Icon name="ph:file-vue" />
+            <p>Accordion.vue</p>
+          </div>
+        </template>
+      </Accordion>
+    </template>
+  </Accordion>
+</template>
+
+<style scoped>
+.unit-file {
+  display: flex;
+  align-items: center;
+  gap: var(--size-space-tiny);
+}
+</style>


### PR DESCRIPTION
## Demo Accordion

## Summary by Sourcery

Add a demo page for the Accordion component with nested examples, improve its styling, and integrate a sidebar link to the new demo

New Features:
- Add DemoAccordion page showcasing nested accordions with icons
- Add 'Accordion' link to the sidebar navigation

Enhancements:
- Refactor Accordion component CSS to use flex layouts and consistent spacing