### PR TITLE
demo page breadcrumb

### DIFF
--- a/pages/DemoBreadcrumb/index.vue
+++ b/pages/DemoBreadcrumb/index.vue
@@ -1,0 +1,38 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import {
+  NuxtLink,
+} from '#components'
+
+import Breadcrumb from '~/components/Breadcrumb.vue'
+
+export default defineComponent({
+  components: {
+    NuxtLink,
+    Breadcrumb,
+  },
+})
+</script>
+
+<template>
+  <div class="unit-demo-breadcrumb">
+    <Breadcrumb />
+
+    <h1>Home Page</h1>
+    <NuxtLink to="/DemoBreadcrumb/users">
+      Go to Users
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.unit-demo-breadcrumb {
+  display: flex;
+  flex-direction: column;
+
+  gap: var(--size-space-large);
+}
+</style>

--- a/pages/DemoBreadcrumb/users/index.vue
+++ b/pages/DemoBreadcrumb/users/index.vue
@@ -21,7 +21,7 @@ export default defineComponent({
   <div class="unit-demo-breadcrumb">
     <Breadcrumb />
 
-    <h1>Settings Page</h1>
+    <h1>Users Page</h1>
     <NuxtLink to="/DemoBreadcrumb">
       Back to Breadcrumb
     </NuxtLink>

--- a/pages/DemoBreadcrumb/users/index.vue
+++ b/pages/DemoBreadcrumb/users/index.vue
@@ -1,0 +1,42 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import {
+  NuxtLink,
+} from '#components'
+
+import Breadcrumb from '~/components/Breadcrumb.vue'
+
+export default defineComponent({
+  components: {
+    NuxtLink,
+    Breadcrumb,
+  },
+})
+</script>
+
+<template>
+  <div class="unit-demo-breadcrumb">
+    <Breadcrumb />
+
+    <h1>Settings Page</h1>
+    <NuxtLink to="/DemoBreadcrumb">
+      Back to Breadcrumb
+    </NuxtLink>
+
+    <NuxtLink to="/DemoBreadcrumb/users/settings">
+      Go to Settings
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.unit-demo-breadcrumb {
+  display: flex;
+  flex-direction: column;
+
+  gap: var(--size-space-large);
+}
+</style>

--- a/pages/DemoBreadcrumb/users/settings/index.vue
+++ b/pages/DemoBreadcrumb/users/settings/index.vue
@@ -1,0 +1,38 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import {
+  NuxtLink,
+} from '#components'
+
+import Breadcrumb from '~/components/Breadcrumb.vue'
+
+export default defineComponent({
+  components: {
+    NuxtLink,
+    Breadcrumb,
+  },
+})
+</script>
+
+<template>
+  <div class="unit-demo-breadcrumb">
+    <Breadcrumb />
+
+    <h1>Settings Page</h1>
+    <NuxtLink to="/DemoBreadcrumb/users">
+      Back to Users
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.unit-demo-breadcrumb {
+  display: flex;
+  flex-direction: column;
+
+  gap: var(--size-space-large);
+}
+</style>


### PR DESCRIPTION
## Demo breadcrumb page

## Summary by Sourcery

Introduce demo pages for the Breadcrumb component across home, users, and users/settings routes, each with navigation links.

New Features:
- Add home demo page at /DemoBreadcrumb showcasing the Breadcrumb component
- Add users demo page at /DemoBreadcrumb/users showcasing the Breadcrumb component
- Add settings demo page at /DemoBreadcrumb/users/settings showcasing the Breadcrumb component

Enhancements:
- Apply scoped flex-column layout with consistent spacing to all demo breadcrumb pages