### PR TITLE
add rule eslint and fix it

### DIFF
--- a/app/helpers/QueryParamManager.js
+++ b/app/helpers/QueryParamManager.js
@@ -3,6 +3,9 @@ import {
   useRouter
 } from 'vue-router'
 
+/**
+ * QueryParamManager
+ */
 export class QueryParamManager {
   /**
    * Constructor of this class.

--- a/composables/useDropdown.js
+++ b/composables/useDropdown.js
@@ -43,7 +43,7 @@ import {
  *   calculatePosition: () => Promise<void>
  * }}
  */
-export default function useDropdown(props) {
+export default useDropdown = (props) => {
   const isOpen = ref(false)
   const dropdownRef = ref(null)
   const contentRef = ref(null)

--- a/composables/useModal.js
+++ b/composables/useModal.js
@@ -5,6 +5,9 @@ import {
   ref,
 } from 'vue'
 
+/**
+ * useModal
+ */
 export function useModal(
   props,
   emit,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import vuePluginConfig from './eslint.js'
+import jsdoc from 'eslint-plugin-jsdoc'
 
 export default [
   {
@@ -13,12 +14,31 @@ export default [
   ...vuePluginConfig,
 
   {
+    plugins: {
+      jsdoc,
+    },
+  },
+
+  {
     rules: {
       complexity: 'off',
 
       '@stylistic/lines-around-comment': 'off',
 
       'vue/attribute-hyphenation': 'off',
+
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          }
+        }
+      ],
     },
   },
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.28.3",
+        "eslint-plugin-jsdoc": "^57.0.8",
         "eslint-plugin-vue": "^10.4.0"
       }
     },
@@ -1825,19 +1826,44 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.53.0.tgz",
-      "integrity": "sha512-Wyed8Wfn3vMNVwrZrgLMxmqwmlcCE1/RfUAOHFzMJb3QLH03mi9Yv1iOCZjif0yx5EZUeJ+17VD1MHPka9IQjQ==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.58.0.tgz",
+      "integrity": "sha512-smMc5pDht/UVsCD3hhw/a/e/p8m0RdRYiluXToVfd+d4yaQQh7nn9bACjkk6nXJvat7EWPAxuFkMEFfrxeGa3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.39.1",
+        "@typescript-eslint/types": "^8.43.0",
         "comment-parser": "1.4.1",
         "esquery": "^1.6.0",
-        "jsdoc-type-pratt-parser": "~4.8.0"
+        "jsdoc-type-pratt-parser": "~5.4.0"
       },
       "engines": {
         "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
+      "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/jsdoc-type-pratt-parser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-5.4.0.tgz",
+      "integrity": "sha512-F9GQ+F1ZU6qvSrZV8fNFpjDNf614YzR2eF6S0+XbDjAcUI28FSoXnYZFjQmb1kFx3rrJb5PnxUH3/Yti6fcM+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3888,6 +3914,90 @@
         "eslint-plugin-format": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nuxt/eslint-config/node_modules/@es-joy/jsdoccomment": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.56.0.tgz",
+      "integrity": "sha512-c6EW+aA1w2rjqOMjbL93nZlwxp6c1Ln06vTYs5FjRRhmJXK8V/OrSXdT+pUr4aRYgjCgu8/OkiZr0tzeVrRSbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.42.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~5.1.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@nuxt/eslint-config/node_modules/@typescript-eslint/types": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
+      "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@nuxt/eslint-config/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nuxt/eslint-config/node_modules/eslint-plugin-jsdoc": {
+      "version": "54.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-54.7.0.tgz",
+      "integrity": "sha512-u5Na4he2+6kY1rWqxzbQaAwJL3/tDCuT5ElDRc5UJ9stOeQeQ5L1JJ1kRRu7ldYMlOHMCJLsY8Mg/Tu3ExdZiQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.56.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.4.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@nuxt/eslint-config/node_modules/jsdoc-type-pratt-parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-5.1.1.tgz",
+      "integrity": "sha512-DYYlVP1fe4QBMh2xTIs20/YeTz2GYVbWAEZweHSZD+qQ/Cx2d5RShuhhsdk64eTjNq0FeVnteP/qVOgaywSRbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@nuxt/eslint-config/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/@nuxt/eslint-plugin": {
@@ -9526,9 +9636,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10550,18 +10660,20 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "54.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-54.1.1.tgz",
-      "integrity": "sha512-qoY2Gl0OkvATXIxRaG2irS2ue78+RTaOyYrADvg1ue+9FHE+2Mp7RcpO0epkuhhQgOkH/REv1oJFe58dYv8SGg==",
+      "version": "57.0.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-57.0.8.tgz",
+      "integrity": "sha512-L3kb1fz1VsWMDxcNOPqomC8gWROxCJomynYZkhQJInZu4m3Ugjod75pWAICRrKW1WedHkX8BotknBtGCLUFpAg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.53.0",
+        "@es-joy/jsdoccomment": "~0.58.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
         "espree": "^10.4.0",
         "esquery": "^1.6.0",
+        "object-deep-merge": "^1.0.5",
         "parse-imports-exports": "^0.2.4",
         "semver": "^7.7.2",
         "spdx-expression-parse": "^4.0.0"
@@ -10577,6 +10689,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10589,6 +10702,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
       "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -15237,6 +15351,29 @@
       },
       "engines": {
         "node": "^14.16.0 || >=16.10.0"
+      }
+    },
+    "node_modules/object-deep-merge": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-1.0.5.tgz",
+      "integrity": "sha512-3DioFgOzetbxbeUq8pB2NunXo8V0n4EvqsWM/cJoI6IA9zghd7cl/2pBOuWRf4dlvA+fcg5ugFMZaN2/RuoaGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "4.2.0"
+      }
+    },
+    "node_modules/object-deep-merge/node_modules/type-fest": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz",
+      "integrity": "sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",
+    "eslint-plugin-jsdoc": "^57.0.8",
     "eslint-plugin-vue": "^10.4.0"
   }
 }


### PR DESCRIPTION
## add rule eslint and fix it

## Summary by Sourcery

Enforce JSDoc documentation by integrating eslint-plugin-jsdoc into the ESLint setup and update existing code to comply with the new rule.

Enhancements:
- Add eslint-plugin-jsdoc to the ESLint configuration and enable the require-jsdoc rule for functions, methods, and class declarations
- Insert JSDoc comments for QueryParamManager class and composable utilities to satisfy the new lint rule
- Refactor useDropdown default export from a function declaration to an arrow function assignment

Build:
- Add eslint-plugin-jsdoc to devDependencies in package.json