### PR TITLE
fix use-dropdown composable

### DIFF
--- a/composables/useDropdown.js
+++ b/composables/useDropdown.js
@@ -11,7 +11,7 @@ import {
   useDebounce
 } from '~/composables/useDebounce'
 
-/**\
+/**
  * Composables for dropdown behavior.
  *
  * Handles:
@@ -43,7 +43,7 @@ import {
  *   calculatePosition: () => Promise<void>
  * }}
  */
-export default useDropdown = (props) => {
+export default function useDropdown(props) {
   const isOpen = ref(false)
   const dropdownRef = ref(null)
   const contentRef = ref(null)


### PR DESCRIPTION
## fix use-dropdown composable

## Summary by Sourcery

Fix the useDropdown composable by correcting the JSDoc comment syntax and switching from an arrow function assignment to a named function declaration.

Bug Fixes:
- Correct the malformed JSDoc opening delimiter in useDropdown.
- Switch useDropdown export from an arrow function assignment to a proper named function declaration.