### PR TITLE
fix backdrop css for header

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -343,6 +343,7 @@
   --size-blur-medium: 4px;
 
   --color-modal-backdrop: rgba(0, 0, 0, 0.5);
+  --color-header-backdrop: rgba(255, 255, 255, 0.5);
 
   --size-max-width: 31.25rem;
   --size-width: calc(50vw - 2rem);

--- a/components/Layout/Header.vue
+++ b/components/Layout/Header.vue
@@ -94,7 +94,8 @@ export default defineComponent({
 
   z-index: 1000;
 
-  background-color: var(--color-gray-50);
+  background-color: var(--color-header-backdrop);
+  backdrop-filter: blur(2px);
 }
 
 .unit-header > .unit-header-container {


### PR DESCRIPTION
## fix backdrop css for header

## Summary by Sourcery

Fix header backdrop styling by using a semi-transparent CSS variable and adding a blur filter

Bug Fixes:
- Use --color-header-backdrop for the header background and apply a 2px backdrop blur

Enhancements:
- Introduce --color-header-backdrop CSS variable set to rgba(255, 255, 255, 0.5)