### PR TITLE
build loading table

### DIFF
--- a/components/Table/SkeletonTable.vue
+++ b/components/Table/SkeletonTable.vue
@@ -1,0 +1,69 @@
+<script>
+import {
+  defineComponent,
+} from 'vue'
+
+import Skeleton from '~/components/Skeleton.vue'
+
+export default defineComponent({
+  name: 'SkeletonTable',
+
+  components: {
+    Skeleton,
+  },
+
+  props: {
+    rows: {
+      type: Number,
+      default: 3
+    },
+    columns: {
+      type: [Number, Array],
+      default: 4
+    },
+  },
+
+  setup(props) {
+    const columnCount = computed(() => {
+      return Array.isArray(props.columns)
+        ? props.columns.length
+        : props.columns
+    })
+
+    const totalCells = computed(() => {
+      return props.rows * columnCount.value
+    })
+
+    return {
+      columnCount,
+      totalCells,
+    }
+  }
+})
+</script>
+
+<template>
+  <div
+    class="skeleton-table"
+    :style="{
+      '--rows': rows,
+      '--columns': columnCount,
+    }"
+  >
+    <Skeleton
+      v-for="n in totalCells"
+      :key="n"
+      type="desc"
+    />
+  </div>
+</template>
+
+<style scoped>
+.skeleton-table {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(var(--columns), 1fr);
+  grid-template-rows: repeat(var(--rows), auto);
+  gap: var(--size-space-small);
+}
+</style>

--- a/components/Table/Table.vue
+++ b/components/Table/Table.vue
@@ -4,12 +4,14 @@ import {
 } from 'vue'
 
 import EmptyState from '~/components/Table/EmptyState.vue'
+import SkeletonTable from '~/components/Table/SkeletonTable.vue'
 
 export default defineComponent({
   name: "Table",
 
   components: {
     EmptyState,
+    SkeletonTable,
   },
 
   props: {
@@ -96,7 +98,10 @@ export default defineComponent({
             class="cell loading"
           >
             <slot name="isLoading">
-              Loading
+              <SkeletonTable
+                :columns="props.columns"
+                :rows="3"
+              />
             </slot>
           </td>
         </tr>


### PR DESCRIPTION
## Build loading table

## Summary by Sourcery

Add a SkeletonTable component and use it for table loading states

New Features:
- Introduce SkeletonTable component to render a grid of skeleton cells as a loading placeholder

Enhancements:
- Render SkeletonTable in the Table component’s loading slot instead of plain text