### PR TITLE
add keyframe for css

### DIFF
--- a/assets/css/keyframes.css
+++ b/assets/css/keyframes.css
@@ -1,0 +1,36 @@
+@keyframes blink {
+  0%, 50% {
+    opacity: 1;
+  }
+  51%, 100% {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-down {
+  from {
+    max-height: 0;
+    opacity: 0;
+  }
+  to {
+    max-height: 60rem;
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes skeleton-pulse {
+  100% {
+    background-position: -100% 0;
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,5 +34,6 @@ export default defineNuxtConfig({
     '~/assets/css/variables.css',
     '~/assets/css/default.css',
     '~/assets/css/fonts.css',
+    '~/assets/css/keyframes.css',
   ]
 })


### PR DESCRIPTION
## add keyframe for css

## Summary by Sourcery

Add a keyframes.css file containing several CSS animations and register it in nuxt.config.ts

New Features:
- Define CSS keyframe animations for blink, slide-down, fadeIn, and skeleton-pulse

Enhancements:
- Include the new keyframes.css file in the Nuxt configuration