### PR TITLE
remove duplicate keyframes

### DIFF
--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -163,16 +163,4 @@ export default defineComponent({
 
   animation: slide-down 250ms ease;
 }
-
-/* Animation for open/close transition */
-@keyframes slide-down {
-  from {
-    max-height: 0;
-    opacity: 0;
-  }
-  to {
-    max-height: 60rem;
-    opacity: 1;
-  }
-}
 </style>

--- a/components/Avatar.vue
+++ b/components/Avatar.vue
@@ -207,15 +207,4 @@ export default defineComponent({
 .avatar .avatar-text {
   animation: fadeIn 0.3s ease-in-out;
 }
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
 </style>

--- a/components/Skeleton.vue
+++ b/components/Skeleton.vue
@@ -64,10 +64,4 @@ export default defineComponent({
   height: var(--skeleton-avatar);
   width: var(--skeleton-avatar);
 }
-
-@keyframes skeleton-pulse {
-  100% {
-    background-position: -100% 0;
-  }
-}
 </style>


### PR DESCRIPTION
## remove duplicate keyframes

## Summary by Sourcery

Remove duplicate CSS keyframe definitions from Accordion, Avatar, and Skeleton components

Enhancements:
- Remove redundant slide-down keyframes from Accordion.vue
- Remove redundant fadeIn keyframes from Avatar.vue
- Remove redundant skeleton-pulse keyframes from Skeleton.vue