### PR TITLE
build query for users

### DIFF
--- a/app/graphql/queries/users/users.capsule.js
+++ b/app/graphql/queries/users/users.capsule.js
@@ -1,0 +1,11 @@
+import ALL_USERS_QUERY from '~/app/graphql/queries/users/users.payload.js'
+
+/**
+ * Capsule.
+ */
+export const allUsersCapsule = (apollo) => {
+  return apollo.query({
+    query: ALL_USERS_QUERY,
+    fetchPolicy: 'network-only',
+  })
+}

--- a/app/graphql/queries/users/users.capsule.js
+++ b/app/graphql/queries/users/users.capsule.js
@@ -6,6 +6,6 @@ import ALL_USERS_QUERY from '~/app/graphql/queries/users/users.payload.js'
 export const allUsersCapsule = (apollo) => {
   return apollo.query({
     query: ALL_USERS_QUERY,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   })
 }

--- a/app/graphql/queries/users/users.launcher.js
+++ b/app/graphql/queries/users/users.launcher.js
@@ -1,0 +1,48 @@
+import {
+  allUsersCapsule,
+} from '~/app/graphql/queries/users/users.capsule.js'
+
+/**
+ * Launcher.
+ *
+ * @returns {{
+ *   users: import('vue').Ref<GraphQLTypes.Users>
+ *   fetchUsers: () => Promise<void>
+ *   error: import('vue').Ref<Error | null>
+ *   loading: import('vue').Ref<Boolean>
+ * }}
+ */
+export const useAllUsersLauncher = () => {
+  const {
+    $apollo,
+  } = useNuxtApp()
+
+  const users = ref([])
+  const loading = ref(false)
+  const error = ref(null)
+
+  const fetchUsers = async () => {
+    loading.value = true
+    error.value = null
+
+    try {
+      const {
+        data,
+      } = await allUsersCapsule($apollo)
+
+      users.value = data.users
+    } catch (err) {
+      error.value = err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    users,
+    loading,
+    error,
+
+    fetchUsers,
+  }
+}

--- a/app/graphql/queries/users/users.payload.js
+++ b/app/graphql/queries/users/users.payload.js
@@ -6,7 +6,7 @@ import {
  * Payload.
  */
 const USERS = gql`
-  query {
+  query getUsers {
     users {
       id
       email

--- a/app/graphql/queries/users/users.payload.js
+++ b/app/graphql/queries/users/users.payload.js
@@ -1,0 +1,19 @@
+import {
+  gql,
+} from '@apollo/client/core'
+
+/**
+ * Payload.
+ */
+const USERS = gql`
+  query {
+    users {
+      id
+      email
+      created_at
+      updated_at
+    }
+  }
+`
+
+export default USERS


### PR DESCRIPTION
## build query for users

## Summary by Sourcery

Introduce GraphQL query for fetching users and integrate it into a Vue launcher composable

New Features:
- Define USERS GraphQL query payload for fetching user fields
- Encapsulate query execution in allUsersCapsule with network-only fetchPolicy
- Implement useAllUsersLauncher composable providing users state, loading, error, and fetchUsers function