### PR TITLE
add restrict merge to author into workflow github

### DIFF
--- a/.github/workflows/restrict-merge.yml
+++ b/.github/workflows/restrict-merge.yml
@@ -1,0 +1,25 @@
+name: Restrict Merge to Author
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  restrict-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Check if merger is PR author
+        run: |
+          AUTHOR=${{ github.event.pull_request.user.login }}
+          MERGER=${{ github.actor }}
+
+          echo "PR Author: $AUTHOR"
+          echo "Merger: $MERGER"
+
+          if [ "$AUTHOR" != "$MERGER" ]; then
+            echo "❌ Only the PR author can merge this pull request."
+            exit 1
+          else
+            echo "✅ Merge allowed (author merged their own PR)."
+          fi


### PR DESCRIPTION
## add restrict merge to author into workflow github

## Summary by Sourcery

Enforce author-only merges by adding a GitHub Actions workflow that checks the merger against the pull request author and rejects the merge if they differ.

New Features:
- Add a GitHub Actions workflow to restrict merges so only the PR author can merge their own pull request

CI:
- Introduce a new workflow file that triggers on closed pull requests and fails if the merger is not the PR author