### PR TITLE
fix query graphql for users

### DIFF
--- a/app/graphql/queries/users/users.capsule.js
+++ b/app/graphql/queries/users/users.capsule.js
@@ -6,6 +6,6 @@ import ALL_USERS_QUERY from '~/app/graphql/queries/users/users.payload.js'
 export const allUsersCapsule = (apollo) => {
   return apollo.query({
     query: ALL_USERS_QUERY,
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'cache-first',
   })
 }

--- a/app/graphql/queries/users/users.launcher.js
+++ b/app/graphql/queries/users/users.launcher.js
@@ -12,7 +12,7 @@ import {
  *   loading: import('vue').Ref<Boolean>
  * }}
  */
-export const useAllUsersLauncher = () => {
+export const useUsersLauncher = () => {
   const {
     $apollo,
   } = useNuxtApp()


### PR DESCRIPTION
## fix query graphql for users

## Summary by Sourcery

Fix users GraphQL query behavior by switching to a cache-first fetch policy and simplify the launcher hook name

Bug Fixes:
- Update users GraphQL query fetch policy to 'cache-first' to fix data fetching behavior

Enhancements:
- Rename useAllUsersLauncher hook to useUsersLauncher for consistency